### PR TITLE
Add inline edit modal for quotations

### DIFF
--- a/main.py
+++ b/main.py
@@ -149,7 +149,7 @@ elif opcion == "Ver Cotizaciones":
 
     # --- Mostrar tabla interactiva con columnas extendidas ---
     st.markdown("### Lista de Cotizaciones")
-    col1, col2, col3, col4, col5, col6, col7, col8, col9, col10 = st.columns([2, 2, 2, 3, 3, 3, 4, 2, 2, 2])
+    col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11 = st.columns([2, 2, 2, 3, 3, 3, 4, 2, 2, 2, 2])
     col1.markdown("**Fecha**")
     col2.markdown("**Última vez**")
     col3.markdown("**Visita**")
@@ -160,9 +160,10 @@ elif opcion == "Ver Cotizaciones":
     col8.markdown("**Enviar**")
     col9.markdown("**Link Auto**")
     col10.markdown("**ID**")
+    col11.markdown("**Editar**")
 
     for index, row in df_paginated.iterrows():
-        r_col1, r_col2, r_col3, r_col4, r_col5, r_col6, r_col7, r_col8, r_col9, r_col10 = st.columns([2, 2, 2, 3, 3, 3, 4, 2, 2, 2])
+        r_col1, r_col2, r_col3, r_col4, r_col5, r_col6, r_col7, r_col8, r_col9, r_col10, r_col11 = st.columns([2, 2, 2, 3, 3, 3, 4, 2, 2, 2, 2])
         r_col1.write(row["fecha_inicio"])
         r_col2.write(row["fecha_ultimo_contacto"])
         r_col3.write(row["visita_programada"])
@@ -194,8 +195,52 @@ elif opcion == "Ver Cotizaciones":
     
         r_col10.write(row["id"])
 
+        if r_col11.button("Editar", key=f"edit_{row['id']}"):
+            st.session_state["edit_id"] = row["id"]
+
+    if st.session_state.get("edit_id"):
+        edit_id = st.session_state["edit_id"]
+        fila = df[df["id"] == edit_id].iloc[0]
+        with st.modal("Editar cotización"):
+            with st.form("form_editar_inline"):
+                fecha_inicio = st.date_input("Fecha inicio", value=pd.to_datetime(fila["fecha_inicio"]).date())
+                nombre = st.text_input("Nombre cliente", value=fila["nombre_cliente"] or "")
+                correo = st.text_input("Correo", value=fila["correo"] or "")
+                telefono = st.text_input("Teléfono", value=fila["telefono"] or "")
+                auto = st.text_input("Auto", value=fila["auto"] or "")
+                link_auto = st.text_input("Link del auto", value=fila["link_auto"] or "")
+                observacion = st.text_area("Observación", value=fila["observacion"] or "")
+                fecha_ultimo = st.date_input("Fecha último contacto", value=pd.to_datetime(fila["fecha_ultimo_contacto"]).date())
+                visita = st.date_input("Visita programada", value=pd.to_datetime(fila["visita_programada"]).date())
+                estado = st.selectbox(
+                    "Estado",
+                    ["Pendiente", "Visitado", "Cerrado", "Otro"],
+                    index=["Pendiente", "Visitado", "Cerrado", "Otro"].index(fila["estado"] or "Pendiente")
+                )
+                col_b1, col_b2 = st.columns([1, 1])
+                with col_b1:
+                    actualizar = st.form_submit_button("Actualizar")
+                with col_b2:
+                    cancelar = st.form_submit_button("Cancelar")
+
+            if actualizar:
+                whatsapp = f"https://wa.me/56{telefono.strip()}"
+                data = (
+                    fecha_inicio.isoformat(), nombre.strip(), correo.strip(), telefono.strip(),
+                    auto.strip(), observacion.strip(), fecha_ultimo.isoformat(),
+                    visita.isoformat(), estado, whatsapp,
+                    link_auto.strip()
+                )
+                actualizar_cotizacion(edit_id, data)
+                st.success("✅ Cotización actualizada.")
+                st.session_state.pop("edit_id", None)
+                st.rerun()
+            if cancelar:
+                st.session_state.pop("edit_id", None)
+
     # --- Edición de cotización por búsqueda ---
     st.subheader("✏️ Buscar para Editar")
+    st.caption("También puedes editar cada fila directamente con el botón 'Editar'.")
     busqueda = st.text_input("Buscar por teléfono o nombre")
     if busqueda:
         df_result = df[


### PR DESCRIPTION
## Summary
- add Edit column to quotations table with per-row edit buttons
- show modal form to update a quotation directly from table rows
- annotate search edit section about new inline editing

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7bfe5ceb8832bba880fe98003dcbc